### PR TITLE
fix argocd server url to access from outside argo namespace

### DIFF
--- a/05_install_decapod.sh
+++ b/05_install_decapod.sh
@@ -46,7 +46,7 @@ print_msg "... done"
 
 print_msg "Run prepare-argocd workflow..."
 ARGOCD_PASSWD=$(kubectl -n argo get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
-argo submit --from wftmpl/prepare-argocd -n argo -p argo_server=argo-cd-argocd-server:80 -p argo_password=$ARGOCD_PASSWD
+argo submit --from wftmpl/prepare-argocd -n argo -p argo_server=argo-cd-argocd-server.argo.svc:80 -p argo_password=$ARGOCD_PASSWD
 argo watch -n argo @latest
 print_msg "... done"
 


### PR DESCRIPTION
cluster-api-aws 차트는 클러스터 이름의 네임스페이스에서 자원이 생성되고 post job 역시 해당 네임스페이스에서 실행됩니다. argocd 서버 주소를 네임스페이스를 포함하도록 수정합니다.