### PR TITLE
fix creating TKS admin cluster kubeconfig

### DIFF
--- a/06_make_tks-admin_self-managing.sh
+++ b/06_make_tks-admin_self-managing.sh
@@ -45,13 +45,13 @@ for ns in cert-manager capi-webhook-system capi-system capi-kubeadm-bootstrap-sy
 done
 print_msg "... done"
 
+export KUBECONFIG=~/.kube/config
+
 print_msg "Copying TKS admin cluster kubeconfig secret to argo namespace"
 kubectl get secret $CLUSTER_NAME-kubeconfig -ojsonpath={.data.value} | base64 -d > value
 kubectl create secret generic tks-admin-kubeconfig-secret -n argo --from-file=value
 rm value
 print_msg "... done"
-
-export KUBECONFIG=~/.kube/config
 
 print_msg  "Pre-check before pivot"
 clusterctl move --to-kubeconfig kubeconfig_$CLUSTER_NAME --dry-run -v10


### PR DESCRIPTION
TKS admin 클러스터 kubeconfig를 argo 네임스페이스에 시크릿으로 생성할 때 빈 내용으로 생성되는 오류를 수정하였습니다.