### PR TITLE
correct the part that copies admin kubeconfig

### DIFF
--- a/06_make_tks-admin_self-managing.sh
+++ b/06_make_tks-admin_self-managing.sh
@@ -49,7 +49,7 @@ export KUBECONFIG=~/.kube/config
 
 print_msg "Copying TKS admin cluster kubeconfig secret to argo namespace"
 kubectl get secret $CLUSTER_NAME-kubeconfig -ojsonpath={.data.value} | base64 -d > value
-kubectl create secret generic tks-admin-kubeconfig-secret -n argo --from-file=value
+kubectl --kubeconfig kubeconfig_$CLUSTER_NAME create secret generic tks-admin-kubeconfig-secret -n argo --from-file=value
 rm value
 print_msg "... done"
 


### PR DESCRIPTION
bootstrap 클러스터의 default 네임스페이스 있는 시크릿을 (신규 생성한) admin 클러스터의 argo 네임스페이스로 복사하는 부분입니다. 상황에 따라 사용해야할 kubeconfig 지정이 누락되어 있어 수정합니다.