### PR TITLE
CAPI 프로바이더 버전 업데이트

### DIFF
--- a/01_prepare_assets.sh
+++ b/01_prepare_assets.sh
@@ -22,8 +22,11 @@ ARGOWF_ASSETS_FILES=(argo-linux-amd64.gz)
 ARGOCD_ASSETS_URL="https://github.com/argoproj/argo-cd/releases"
 ARGOCD_ASSETS_FILES=(argocd-linux-amd64)
 GUM_ASSETS_URL="https://github.com/charmbracelet/gum/releases"
-GUM_ASSETS_FILES=(gum_0.7.0_linux_x86_64.tar.gz)
-GUM_VERSION="v0.7.0"
+GUM_ASSETS_FILES=(gum_0.9.0_linux_x86_64.tar.gz)
+GUM_VERSION="v0.9.0"
+GITEA_ASSETS_URL="https://github.com/go-gitea/gitea/releases"
+GITEA_ASSETS_FILES=(gitea-1.18.1-linux-amd64)
+GITEA_VERSION="v1.8.1"
 
 # Git repos
 # "repo_url,tag/branch,dest_dir"
@@ -245,11 +248,6 @@ pull_workflow_images tks-flow
 
 log_info "Downloading kubectl"
 curl -sL -o $ASSETS_DIR/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-
-log_info "Downloading gitea"
-curl -sL -o $ASSETS_DIR/gitea https://dl.gitea.io/gitea/1.17.3/gitea-1.17.3-linux-amd64
-chmod +x $ASSETS_DIR/gitea
-
 
 cd $ASSETS_DIR
 [ ! -L bootstrap-kubeadm ] && ln -s cluster-api bootstrap-kubeadm

--- a/03_initialize_capi_providers.sh
+++ b/03_initialize_capi_providers.sh
@@ -29,8 +29,8 @@ providers:
   - name: "aws"
     url: "file://localhost$(realpath $1)/infrastructure-aws/$CAPA_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
-  - name: "openstack"
-    url: "file://localhost$(realpath $1)/infrastructure-openstack/$CAPO_VERSION/infrastructure-components.yaml"
+  - name: "byoh"
+    url: "file://localhost$(realpath $1)/infrastructure-byoh/$CAPO_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 EOF
 

--- a/80_upgrade_capi_providers.sh
+++ b/80_upgrade_capi_providers.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+source lib/common.sh
+
+if [ -z "$1" ]
+  then
+    echo "usage: $0 <assets dir>"
+    exit 1
+fi
+
+log_info "Preparing to upgrade Cluster API providers"
+
+sudo cp $1/cluster-api/$CAPI_VERSION/clusterctl-linux-amd64 /usr/local/bin/clusterctl
+sudo chmod +x /usr/local/bin/clusterctl
+clusterctl version
+
+gum confirm "Is it the same version ($CAPI_VERSION) you want to use?" || exit 1
+
+cat > clusterctl.yaml <<EOF
+providers:
+  - name: "cluster-api"
+    url: "file://localhost$(realpath $1)/cluster-api/$CAPI_VERSION/core-components.yaml"
+    type: "CoreProvider"
+  - name: "kubeadm"
+    url: "file://localhost$(realpath $1)/bootstrap-kubeadm/$CAPI_VERSION/bootstrap-components.yaml"
+    type: "BootstrapProvider"
+  - name: "kubeadm"
+    url: "file://localhost$(realpath $1)/control-plane-kubeadm/$CAPI_VERSION/control-plane-components.yaml"
+    type: "ControlPlaneProvider"
+  - name: "aws"
+    url: "file://localhost$(realpath $1)/infrastructure-aws/$CAPA_VERSION/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+  - name: "byoh"
+    url: "file://localhost$(realpath $1)/infrastructure-byoh/$CAPO_VERSION/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+EOF
+
+mkdir -p ~/.cluster-api
+cp clusterctl.yaml ~/.cluster-api/
+
+log_info "Identifying possible targets for upgrades"
+clusterctl upgrade plan
+
+gum confirm "Are you sure you want to upgrade cluster api providers?" || exit 1
+log_info "Applying new versions of Cluster API components"
+
+for provider in ${CAPI_INFRA_PROVIDERS[@]}
+do
+	case $provider in
+		"aws")
+			sudo cp $1/cluster-api-provider-aws/$CAPA_VERSION/clusterawsadm-linux-amd64 /usr/local/bin/clusterawsadm
+			sudo chmod +x /usr/local/bin/clusterawsadm
+
+			export AWS_REGION
+			export AWS_ACCESS_KEY_ID
+			export AWS_SECRET_ACCESS_KEY
+
+			export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm bootstrap credentials encode-as-profile)
+			export EXP_MACHINE_POOL=true
+			;;
+		"byoh")
+			;;
+	esac
+done
+
+clusterctl upgrade apply --contract v1beta1
+log_info "...Done"

--- a/lib/versions.sh
+++ b/lib/versions.sh
@@ -5,9 +5,9 @@ ARGOCD_CHART_VERSION="4.10.9"
 CAPI_RELEASE="v1beta1"
 case $CAPI_RELEASE in
         "v1beta1")
-                CAPI_VERSION="v1.2.4"
-                CAPA_VERSION="v1.5.0"
-                BYOH_VERSION="v0.3.0"
+                CAPI_VERSION="v1.3.2"
+                CAPA_VERSION="v2.0.2"
+                BYOH_VERSION="v0.3.1"
                 ;;
 esac
 


### PR DESCRIPTION
아래와 같이 각 CAPI 컴포넌트 별 버전을 최신으로 업데이트하였습니다.

- Cluster API: v1.2.4 -> v1.3.2
- Cluster API Provider AWS: v1.5.0 -> v2.0.2
- Cluster API Provider BYOH: v0.3.0 -> v0.3.1

또한, 기존 어드민(management) 클러스터의 CAPI 컨트롤러를 업그레이드 하는 스크립트(80_upgrade_capi_providers.sh)도 추가하였습니다.

dev 어드민 클러스터에 최신 버전 적용하였습니다.