### PR TITLE
Gitea 서비스 노드 포트 사용 및 BYOH 컨트롤러 TKS 자체 버전 사용

### DIFF
--- a/lib/versions.sh
+++ b/lib/versions.sh
@@ -9,7 +9,7 @@ case $CAPI_RELEASE in
                 CAPI_VERSION="v1.5.0"
                 CAPA_VERSION="v2.2.1"
                 BYOH_VERSION="v0.4.0"
-                BYOH_TKS_VERSION="dev24"
+                BYOH_TKS_VERSION="v0.4.0-tks-20231017"
                 ;;
 esac
 

--- a/templates/helm-gitea.vo.template
+++ b/templates/helm-gitea.vo.template
@@ -1,3 +1,9 @@
+service:
+  http:
+    type: NodePort
+    nodePort: 30303
+    externalTrafficPolicy: Local
+
 ingress:
   hosts:
     - host: localhost


### PR DESCRIPTION
- gitea 접근을 수월하게 하기 위해 노드 포트 서비스로 변경
- BYOH 컨트롤러를 TKS 자체 버전(https://github.com/openinfradev/cluster-api-provider-bringyourownhost/)으로 사용