### PR TITLE
fix byoh-hostagent upload

### DIFF
--- a/05_install_decapod.sh
+++ b/05_install_decapod.sh
@@ -321,7 +321,7 @@ case $TKS_ADMIN_CLUSTER_INFRA_PROVIDER in
 
 			# BYOH
 			curl -v --user tks_admin:$GIT_SVC_TOKEN -X DELETE $GIT_SVC_HTTP://${GIT_SVC_BASE_URL}/api/packages/decapod10/generic/byoh_hostagent/$BYOH_TKS_VERSION/byoh-hostagent-linux-amd64 || true
-			curl -v --user tks_admin:$GIT_SVC_TOKEN --upload-file output/byoh-hostagent-linux-amd64 $GIT_SVC_HTTP://${GIT_SVC_BASE_URL}/api/packages/decapod10/generic/byoh_hostagent/$BYOH_TKS_VERSION/byoh-hostagent-linux-amd64
+			curl -v --user tks_admin:$GIT_SVC_TOKEN --upload-file output/byoh-hostagent $GIT_SVC_HTTP://${GIT_SVC_BASE_URL}/api/packages/decapod10/generic/byoh_hostagent/$BYOH_TKS_VERSION/byoh-hostagent-linux-amd64
 		;;
 esac
 
@@ -338,7 +338,7 @@ kubectl delete secret tks-admin-kubeconfig-secret -n argo || true
 kubectl create secret generic tks-admin-kubeconfig-secret -n argo --from-file=value=$TKS_KUBECONFIG_ADMIN
 kubectl delete secret byoh-hostagent-install-template -n argo || true
 cp templates/install_byoh_hostagent.sh.template templates/install_byoh_hostagent.sh.template.orig
-HOSTAGENT_CHECKSUM=$(sha1sum output/byoh-hostagent-linux-amd64 | awk '{print $1}')
+HOSTAGENT_CHECKSUM=$(sha1sum output/byoh-hostagent | awk '{print $1}')
 export HOSTAGENT_CHECKSUM BYOH_TKS_VERSION GIT_SVC_USERNAME GITEA_NODE_PORT GITEA_NODE_IP
 envsubst '$HOSTAGENT_CHECKSUM $BYOH_TKS_VERSION $GIT_SVC_USERNAME $GITEA_NODE_IP $GITEA_NODE_PORT' < templates/install_byoh_hostagent.sh.template.orig > templates/install_byoh_hostagent.sh.template
 kubectl create secret generic byoh-hostagent-install-template -n argo --from-file=agent-install-template=templates/install_byoh_hostagent.sh.template

--- a/byoh_generate_script_for_host.sh
+++ b/byoh_generate_script_for_host.sh
@@ -92,4 +92,4 @@ envsubst '$BOOTSTRAP_KUBECONFIG $GITEA_NODE_IP $GITEA_NODE_PORT $GIT_SVC_USERNAM
 chmod +x $OUTPUT_SCRIPT_PATH
 
 log_info "Copy below files to each host and run a script!"
-echo "$OUTPUT_SCRIPT_PATH output/byoh-hostagent-linux-amd64"
+echo "$OUTPUT_SCRIPT_PATH output/byoh-hostagent"


### PR DESCRIPTION
byoh-hostagent 바이너리 파일명의 OS-ARCH 접미사 제거로 인한 오류를 수정합니다.