### PR TITLE
aws-admin: use gp3 type for ebs

### DIFF
--- a/helm-values/example-aws-admin.vo
+++ b/helm-values/example-aws-admin.vo
@@ -26,7 +26,7 @@ machinePool:
   maxSize: 3
   rootVolume:
     size: 200
-    type: gp2
+    type: gp3
   labels:
     taco-tks: enabled
     taco-lma: enabled


### PR DESCRIPTION
AWS 어드민 클러스터 구성 시 EBS 볼륨을 gp3 사용하도록 변경합니다.